### PR TITLE
fix: pass secrets to shared workflow

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   notify-external:
     uses: ./.github/workflows/issue-notify-external.yml
+    secrets: inherit
     with:
       issue_creator: ${{ github.event.issue.user.login }}
       issue_title: ${{ github.event.issue.title }}


### PR DESCRIPTION
# Summary
Update the calling workflow to pass its secrets.  This should fix the missing SRE app and Slack webhook secrets.

# Related
- https://github.com/cds-snc/platform-core-services/issues/905
- [Passing secrets to shared workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-secrets-to-nested-workflows)