### PR TITLE
fix: escape control characters in issue title

### DIFF
--- a/.github/workflows/issue-notify-external.yml
+++ b/.github/workflows/issue-notify-external.yml
@@ -55,7 +55,7 @@ jobs:
           ISSUE_URL: ${{ inputs.issue_url }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |          
-          ISSUE_TITLE=$(echo "$ISSUE_TITLE" | sed 's/"/\\"/g')
+          ISSUE_TITLE=$(echo "$ISSUE_TITLE" | sed 's/&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g' | sed 's/"/\\"/g')
           json=$(cat <<EOF
           {
           "blocks": [


### PR DESCRIPTION
# Summary | Résumé
Make sure that the following characters are escaped before sending the message to the Slack API:
```
&
<
>
```
