### PR TITLE
chore: create a template for planned maintenance updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_deps_template.md
+++ b/.github/ISSUE_TEMPLATE/dev_deps_template.md
@@ -1,0 +1,37 @@
+---
+name: Planned dependency maintenance
+about: Recurring sprint task for updating dependencies (per repo)
+title: 'Dev: Planned dependency maintenance - <repo-name> - <sprint/date>'
+labels: 'development'
+assignees: ''
+---
+
+## 📇 User story
+
+**As a** maintainer of `<repo-name>`,  
+**I want to** review and update dependencies,  
+**so that** the repo remains secure and stable.
+
+
+
+## ✅ Definition of Done
+- [ ] Outdated dependencies reviewed
+- [ ] Safe updates applied (patch/minor)
+- [ ] Major updates documented (update or defer)
+- [ ] Build/tests pass
+- [ ] Lockfile updated (if applicable)
+
+
+## 📜 Acceptance criteria
+- [ ] No unresolved high/critical vulnerabilities
+- [ ] CI passes
+- [ ] Semver impact reviewed (if publishing)
+
+
+
+## 📝 More info
+
+
+## 🚫 Out of scope
+- Major refactors
+- Unrelated feature work


### PR DESCRIPTION
# Summary | Résumé
Adds a template for planned maintenance and dependency updates we can use for every sprint

## 🔗 Related Issues | Cartes liées
- Closes #2274 
