### PR TITLE
fix: fail the issue notify workflow if no post

### DIFF
--- a/.github/workflows/issue-notify-external.yml
+++ b/.github/workflows/issue-notify-external.yml
@@ -70,4 +70,11 @@ jobs:
           }
           EOF
           )
-          curl -X POST -H 'Content-type: application/json' --data "$json" "$SLACK_WEBHOOK_URL"
+          HTTP_CODE=$(curl -sS -o /tmp/slack-webhook-response -w "%{http_code}" \
+            -X POST -H 'Content-type: application/json' --data "$json" "$SLACK_WEBHOOK_URL")
+
+          if [[ "$HTTP_CODE" != "200" ]]; then
+            echo "Slack notification failed with HTTP status $HTTP_CODE"
+            cat /tmp/slack-webhook-response
+            exit 1
+          fi


### PR DESCRIPTION
# 🎯 Summary | Résumé

Update the issue notify workflow so that if the Slack message is not posted, the workflow is marked as failed.

# 🔗 Related Issues | Cartes liées

n/a

# 🚧 Test instructions | Instructions pour tester la modification

Have a non Design System team member create a GitHub issue and expect it to post to Slack.  I tested this locally with a script.

# ✅ Author checklist | Liste de vérification de l'auteur

- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes.
- [ ] I have tested the English and French versions of the site and verified that all content is accurate and properly displayed in both languages.
- [ ] I have tested these changes on Mobile.
- [ ] I have tested these changes across multiple browsers.
- [ ] I have checked accessiblity and ensured all accessiblity tests pass. :accessibility:
- [ ] I have added tests for added functionality or changed existing tests, as needed.
- [ ] I have added or updated documentation, if needed.
- [ ] For visual design changes, post in dev-design slack channel

# 📝 Reviewer checklist | Liste de vérification du réviseur

- [ ] I have tested the changes and functionality (locally or on codespaces) using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

# ⚠️ Impact/Risks | Risques

None
